### PR TITLE
Internal evaluations export improvements

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
             values:
               "false": Not evaluated
               "true": Evaluated
+    download_your_data:
+      show:
+        internal_evaluations: Internal evaluations
     internal_evaluation:
       admin:
         internal_evaluations:

--- a/lib/decidim/internal_evaluation/export.rb
+++ b/lib/decidim/internal_evaluation/export.rb
@@ -12,11 +12,15 @@ module Decidim
       #
       # Returns an Arel::Relation with all the internal evaluations for that component and resource.
       def internal_evaluations_for_resource(resource_class, component, user)
-        filtered_collection(resource_class, component, user).map do |resource|
-          resource.valuation_assignments.map do |assignment|
-            InternalEvaluation.find_or_initialize_by(proposal: resource, author: assignment.valuator)
+        filtered_collection(resource_class, component, user).map do |proposal|
+          proposal.valuation_assignments.map do |assignment|
+            author = assignment.valuator_role&.user
+
+            next if author.blank?
+
+            InternalEvaluation.find_or_initialize_by(proposal:, author:)
           end
-        end.flatten
+        end.flatten.compact
       end
 
       # Internal: Returns the filtered collection for the given resource class, component and user.

--- a/lib/decidim/internal_evaluation/export.rb
+++ b/lib/decidim/internal_evaluation/export.rb
@@ -12,20 +12,42 @@ module Decidim
       #
       # Returns an Arel::Relation with all the internal evaluations for that component and resource.
       def internal_evaluations_for_resource(resource_class, component, user)
-        participatory_space = component.participatory_space
-        collection = resource_class.not_hidden.published.where(component:)
-        user_is_valuator = participatory_space.user_roles(:valuator).where(user:).any?
-
-        filtered_collection = if user_is_valuator
-                                collection.with_valuation_assigned_to(user, participatory_space)
-                              else
-                                collection
-                              end
-
-        InternalEvaluation.where(proposal: filtered_collection.pluck(:id))
+        filtered_collection(resource_class, component, user).map do |resource|
+          resource.valuation_assignments.map do |assignment|
+            InternalEvaluation.find_or_initialize_by(proposal: resource, author: assignment.valuator)
+          end
+        end.flatten
       end
 
-      module_function :internal_evaluations_for_resource
+      # Internal: Returns the filtered collection for the given resource class, component and user.
+      #
+      # resource_class - The resource's Class
+      # component      - The component where the resource is scoped to.
+      # user           - The user that is requesting the export.
+      #
+      # Returns an Arel::Relation with the filtered collection.
+      def filtered_collection(resource_class, component, user)
+        return @collection if @collection
+
+        collection = resource_class
+          .not_hidden
+          .published
+          .where(component:)
+          .where.not(valuation_assignments_count: 0)
+
+        participatory_space = component.participatory_space
+        user_is_valuator = participatory_space.user_roles(:valuator).where(user:).any?
+
+        @collection = if user_is_valuator
+                        collection.with_valuation_assigned_to(user, participatory_space)
+                      else
+                        collection
+                      end
+
+        @collection
+      end
+
+      module_function :internal_evaluations_for_resource, :filtered_collection
     end
   end
 end

--- a/lib/decidim/internal_evaluation/internal_evaluation_serializer.rb
+++ b/lib/decidim/internal_evaluation/internal_evaluation_serializer.rb
@@ -11,13 +11,15 @@ module Decidim
       # Serializes an internal evaluation
       def serialize
         {
-          id: resource.id,
-          created_at: resource.created_at,
-          status: translated_attribute(resource.internal_state&.title),
-          text: convert_to_text(resource.body),
-          evaluator_name: resource.author.name,
-          proposal_title: translated_attribute(proposal.title),
-          proposal_description: convert_to_text(translated_attribute(proposal.body))
+          id: resource.id || "",
+          created_at: resource.created_at || "",
+          status: resource.internal_state.present? ? translated_attribute(resource.internal_state.title) : "",
+          text: resource.body.present? ? convert_to_text(resource.body) : "",
+          evaluator_name: resource.author.name || "",
+          proposal_title: translated_attribute(proposal.title) || "",
+          proposal_description: convert_to_text(translated_attribute(proposal.body)) || "",
+          scope: translated_attribute(proposal.scope&.name) || "",
+          category: translated_attribute(proposal.category&.name) || ""
         }
       end
 

--- a/lib/decidim/internal_evaluation/internal_evaluation_serializer.rb
+++ b/lib/decidim/internal_evaluation/internal_evaluation_serializer.rb
@@ -16,6 +16,7 @@ module Decidim
           status: resource.internal_state.present? ? translated_attribute(resource.internal_state.title) : "",
           text: resource.body.present? ? convert_to_text(resource.body) : "",
           evaluator_name: resource.author.name || "",
+          proposal_id: proposal.id || "",
           proposal_title: translated_attribute(proposal.title) || "",
           proposal_description: convert_to_text(translated_attribute(proposal.body)) || "",
           scope: translated_attribute(proposal.scope&.name) || "",

--- a/spec/services/decidim/internal_evaluation/internal_evaluation_serializer_spec.rb
+++ b/spec/services/decidim/internal_evaluation/internal_evaluation_serializer_spec.rb
@@ -10,12 +10,14 @@ module Decidim
       end
 
       let(:internal_evaluation) { create(:internal_evaluation, body:, internal_state:, proposal:) }
-      let(:proposal) { create(:proposal, title: proposal_title, body: proposal_body) }
+      let(:proposal) { create(:proposal, title: proposal_title, body: proposal_body, scope:, category:) }
       let(:internal_state) { create(:proposal_state, component: proposal.component, title: state_title) }
       let(:body) { "The body" }
       let(:state_title) { { en: "Accepted", es: "Aceptado" } }
       let(:proposal_title) { { en: "The title", es: "El título" } }
       let(:proposal_body) { { en: "The body", es: "El cuerpo" } }
+      let(:scope) { create(:scope, name: { en: "Scope", es: "Alcance" }) }
+      let(:category) { create(:category, name: { en: "Category", es: "Categoría" }) }
 
       describe "#serialize" do
         let(:serialized) { subject.serialize }
@@ -28,6 +30,8 @@ module Decidim
           expect(serialized).to include(evaluator_name: internal_evaluation.author.name)
           expect(serialized).to include(proposal_title: "The title")
           expect(serialized).to include(proposal_description: "The body")
+          expect(serialized).to include(scope: "Scope")
+          expect(serialized).to include(category: "Category")
         end
       end
     end

--- a/spec/services/decidim/internal_evaluation/internal_evaluation_serializer_spec.rb
+++ b/spec/services/decidim/internal_evaluation/internal_evaluation_serializer_spec.rb
@@ -9,15 +9,18 @@ module Decidim
         described_class.new(internal_evaluation)
       end
 
+      let(:organization) { create(:organization) }
+      let(:scope) { create(:scope, name: { en: "Scope", es: "Alcance" }, organization:) }
+      let(:category) { create(:category, name: { en: "Category", es: "Categoría" }, participatory_space:) }
+      let(:participatory_space) { create(:participatory_process, organization:) }
+      let(:component) { create(:proposal_component, :with_attachments_allowed, participatory_space:) }
       let(:internal_evaluation) { create(:internal_evaluation, body:, internal_state:, proposal:) }
-      let(:proposal) { create(:proposal, title: proposal_title, body: proposal_body, scope:, category:) }
+      let(:proposal) { create(:proposal, title: proposal_title, body: proposal_body, component:, scope:, category:) }
       let(:internal_state) { create(:proposal_state, component: proposal.component, title: state_title) }
       let(:body) { "The body" }
       let(:state_title) { { en: "Accepted", es: "Aceptado" } }
       let(:proposal_title) { { en: "The title", es: "El título" } }
       let(:proposal_body) { { en: "The body", es: "El cuerpo" } }
-      let(:scope) { create(:scope, name: { en: "Scope", es: "Alcance" }) }
-      let(:category) { create(:category, name: { en: "Category", es: "Categoría" }) }
 
       describe "#serialize" do
         let(:serialized) { subject.serialize }


### PR DESCRIPTION
Closes https://github.com/AjuntamentdeBarcelona/decidim-internal-evaluation-module/issues/9

- Adds pending evaluations to the export (assigned evaluations).
- Adds "proposal_id", "scope" and "category" columns. 